### PR TITLE
Fixed a typo in the build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,5 +21,5 @@ $ npm install            # Download dependencies
 $ npm start              # Start Knowte
 $ npm run electron:windows   # Build for Windows
 $ npm run electron:linux     # Build for Linux
-$ npm run electron:mac       # Build for Linux
+$ npm run electron:mac       # Build for Mac
 ```


### PR DESCRIPTION
The code previously, erroneously, said "npm run electron: mac" builds for linux, which it definitely does not.